### PR TITLE
CI: Add EAS build/update workflows

### DIFF
--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -1,0 +1,67 @@
+name: EAS Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: "ios | android | all"
+        required: true
+        default: "ios"
+        type: choice
+        options: [ios, android, all]
+      profile:
+        description: "EAS build profile"
+        required: true
+        default: "preview"
+        type: choice
+        options: [preview, production]
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install deps
+        run: npm ci --no-audit --no-fund
+
+      - name: Install EAS CLI
+        run: npm i -g eas-cli
+
+      - name: EAS whoami
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: eas whoami || true
+
+      - name: Build
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: |
+          if [ -z "${EXPO_TOKEN:-}" ]; then
+            echo "EXPO_TOKEN is not set; skipping EAS Build. Add EXPO_TOKEN to repo secrets to enable builds.";
+            exit 0;
+          fi
+
+          PLATFORM="${{ inputs.platform || 'ios' }}"
+          PROFILE="${{ inputs.profile || 'preview' }}"
+          if [ -z "$PLATFORM" ]; then PLATFORM="ios"; fi
+          if [ -z "$PROFILE" ]; then PROFILE="preview"; fi
+
+          if [ "$PLATFORM" = "all" ]; then
+            eas build --platform ios --profile "$PROFILE" --non-interactive
+            eas build --platform android --profile "$PROFILE" --non-interactive
+          else
+            eas build --platform "$PLATFORM" --profile "$PROFILE" --non-interactive
+          fi

--- a/.github/workflows/eas-update.yml
+++ b/.github/workflows/eas-update.yml
@@ -1,0 +1,53 @@
+name: EAS Update
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "EAS Update branch"
+        required: true
+        default: "main"
+        type: string
+      message:
+        description: "Update message"
+        required: true
+        default: "CI update"
+        type: string
+  push:
+    branches: [ main ]
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install deps
+        run: npm ci --no-audit --no-fund
+
+      - name: Install EAS CLI
+        run: npm i -g eas-cli
+
+      - name: EAS Update
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: |
+          if [ -z "${EXPO_TOKEN:-}" ]; then
+            echo "EXPO_TOKEN is not set; skipping EAS Update. Add EXPO_TOKEN to repo secrets to enable updates.";
+            exit 0;
+          fi
+
+          BRANCH="${{ inputs.branch || 'main' }}"
+          MSG="${{ inputs.message || github.sha }}"
+          if [ -z "$BRANCH" ]; then BRANCH="main"; fi
+          if [ -z "$MSG" ]; then MSG="${GITHUB_SHA}"; fi
+          eas update --branch "$BRANCH" --message "$MSG" --non-interactive


### PR DESCRIPTION
Adds EAS Build and Update workflows for CI/CD integration.

- EAS Build: Manual dispatch and tag-triggered builds
- EAS Update: Manual dispatch and push-to-main OTA updates
- Both workflows gracefully skip if EXPO_TOKEN is not set